### PR TITLE
Add internal TLS support via Caddy for demo environment

### DIFF
--- a/cmd/go-fim/main.go
+++ b/cmd/go-fim/main.go
@@ -59,7 +59,7 @@ func run() (err error) {
 
 	var httpClient *client.Client
 	if cfg.ServerURL != "" {
-		httpClient = client.New(cfg.ServerURL)
+		httpClient = client.New(cfg.ServerURL, cfg.InsecureSkipVerify)
 	}
 
 	// Drain any reports queued by previous runs before kicking off the fresh

--- a/demo/Caddyfile
+++ b/demo/Caddyfile
@@ -1,0 +1,4 @@
+caddy, localhost {
+	tls internal
+	reverse_proxy server:8000
+}

--- a/demo/alpha.gofim.yml
+++ b/demo/alpha.gofim.yml
@@ -12,4 +12,5 @@ exclude:
 verbose: false
 db: /data/snapshot.db
 history_dir: /data/history
-server_url: http://server:8000
+server_url: https://caddy
+insecure_skip_verify: true

--- a/demo/bravo.gofim.yml
+++ b/demo/bravo.gofim.yml
@@ -12,4 +12,5 @@ exclude:
 verbose: false
 db: /data/snapshot.db
 history_dir: /data/history
-server_url: http://server:8000
+server_url: https://caddy
+insecure_skip_verify: true

--- a/demo/charlie.gofim.yml
+++ b/demo/charlie.gofim.yml
@@ -12,4 +12,5 @@ exclude:
 verbose: false
 db: /data/snapshot.db
 history_dir: /data/history
-server_url: http://server:8000
+server_url: https://caddy
+insecure_skip_verify: true

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -47,7 +47,7 @@ services:
 
   agent-charlie:
     image: go-fim-agent
-    depends_on: [agent-alpha]
+    depends_on: [agent-alpha, caddy]
     volumes:
       - ${HOME}/Developer/Personal:${HOME}/Developer/Personal:ro
       - charlie-data:/data

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   agent-bravo:
     image: go-fim-agent
-    depends_on: [agent-alpha]
+    depends_on: [agent-alpha, caddy]
     volumes:
       - ${HOME}/Developer/Learning:${HOME}/Developer/Learning:ro
       - bravo-data:/data

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -9,15 +9,26 @@ services:
       GOFIM_DB_PATH: /data/server.db
     volumes:
       - server-data:/data
+    # Expose only to internal network; Caddy handles external access
+    expose:
+      - "8000"
+
+  caddy:
+    image: caddy:2-alpine
+    depends_on: [server]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
     ports:
-      - "8000:8000"
+      - "443:443"
+      - "80:80"
 
   agent-alpha:
     build:
       context: ..
       dockerfile: build/agent.Dockerfile
     image: go-fim-agent
-    depends_on: [server]
+    depends_on: [caddy]
     # Bind-mount host path at the SAME absolute path inside the container so
     # report entries reference the real host paths, not /scan/...  Trade-off:
     # hardcodes /Users/arishkumar/... into compose; fine for single-user demo.
@@ -28,7 +39,7 @@ services:
 
   agent-bravo:
     image: go-fim-agent
-    depends_on: [server, agent-alpha]
+    depends_on: [agent-alpha]
     volumes:
       - ${HOME}/Developer/Learning:${HOME}/Developer/Learning:ro
       - bravo-data:/data
@@ -36,7 +47,7 @@ services:
 
   agent-charlie:
     image: go-fim-agent
-    depends_on: [server, agent-alpha]
+    depends_on: [agent-alpha]
     volumes:
       - ${HOME}/Developer/Personal:${HOME}/Developer/Personal:ro
       - charlie-data:/data
@@ -44,6 +55,7 @@ services:
 
 volumes:
   server-data:
+  caddy-data:
   alpha-data:
   bravo-data:
   charlie-data:

--- a/gofim.yml
+++ b/gofim.yml
@@ -24,3 +24,7 @@ history_dir: ./history
 
 # Control-plane URL. Empty/absent = standalone mode (no register, no POST).
 server_url: http://localhost:8000
+
+# Skip TLS certificate verification for server_url (useful with internal CAs).
+# WARNING: Only use in development/testing environments with self-signed certs.
+insecure_skip_verify: false

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ package client
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,11 +40,16 @@ type Client struct {
 	HTTP    *http.Client
 }
 
-func New(baseURL string) *Client {
+func New(baseURL string, insecureSkipVerify bool) *Client {
 	return &Client{
 		BaseURL: baseURL,
-		HTTP:    &http.Client{Timeout: 5 * time.Second},
-	}
+		HTTP: &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+			},
+		},
+	}	
 }
 
 // SendReport POSTs the report. Caller fills rep.AgentID / rep.AgentName /

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -44,12 +44,12 @@ func New(baseURL string, insecureSkipVerify bool) *Client {
 	return &Client{
 		BaseURL: baseURL,
 		HTTP: &http.Client{
-			Timeout:   5 * time.Second,
+			Timeout: 5 * time.Second,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 			},
 		},
-	}	
+	}
 }
 
 // SendReport POSTs the report. Caller fills rep.AgentID / rep.AgentName /

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	HistoryDir         string
 	ServerURL          string // empty = standalone mode (no POST)
 	AgentName          string // operator-chosen display label, sent on every /report
-	InsecureSkipVerify bool   // skip TLS cert verification (for internal CAs)
+	InsecureSkipVerify bool   // disable TLS certificate verification entirely
 }
 
 // rawConfig matches the on-disk YAML shape; we translate it into Config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,26 +12,28 @@ import (
 
 // Config is the runtime config after parsing + regex compilation.
 type Config struct {
-	Path       string
-	Exclude    []*regexp.Regexp
-	Verbose    bool
-	DBPath     string
-	HistoryDir string
-	ServerURL  string // empty = standalone mode (no POST)
-	AgentName  string // operator-chosen display label, sent on every /report
+	Path               string
+	Exclude            []*regexp.Regexp
+	Verbose            bool
+	DBPath             string
+	HistoryDir         string
+	ServerURL          string // empty = standalone mode (no POST)
+	AgentName          string // operator-chosen display label, sent on every /report
+	InsecureSkipVerify bool   // skip TLS cert verification (for internal CAs)
 }
 
 // rawConfig matches the on-disk YAML shape; we translate it into Config
 // (compiling regexes, resolving paths) so the rest of the program sees
 // ready-to-use types.
 type rawConfig struct {
-	Path      string   `yaml:"path"`
-	Exclude   []string `yaml:"exclude"`
-	Verbose   bool     `yaml:"verbose"`
-	DB        string   `yaml:"db"`
-	History   string   `yaml:"history_dir"`
-	ServerURL string   `yaml:"server_url"`
-	AgentName string   `yaml:"agent_name"`
+	Path               string   `yaml:"path"`
+	Exclude            []string `yaml:"exclude"`
+	Verbose            bool     `yaml:"verbose"`
+	DB                 string   `yaml:"db"`
+	History            string   `yaml:"history_dir"`
+	ServerURL          string   `yaml:"server_url"`
+	AgentName          string   `yaml:"agent_name"`
+	InsecureSkipVerify bool     `yaml:"insecure_skip_verify"`
 }
 
 const (
@@ -80,12 +82,13 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		Path:       resolvedRoot,
-		Verbose:    raw.Verbose,
-		DBPath:     resolvedDB,
-		HistoryDir: resolvedHistory,
-		ServerURL:  raw.ServerURL,
-		AgentName:  raw.AgentName,
+		Path:               resolvedRoot,
+		Verbose:            raw.Verbose,
+		DBPath:             resolvedDB,
+		HistoryDir:         resolvedHistory,
+		ServerURL:          raw.ServerURL,
+		AgentName:          raw.AgentName,
+		InsecureSkipVerify: raw.InsecureSkipVerify,
 	}
 	for i, pat := range raw.Exclude {
 		re, err := regexp.Compile(pat)


### PR DESCRIPTION
This pull request updates the demo environment to use HTTPS with a Caddy reverse proxy, and adds support for skipping TLS certificate verification for development and internal CA use cases. It introduces a new `insecure_skip_verify` configuration option, updates the client to honor this setting, and modifies the Docker Compose setup to route all external traffic through Caddy for improved security and flexibility.

**Demo environment and networking improvements:**

* Added a Caddy reverse proxy (`caddy` service) to the demo environment, terminating TLS and forwarding requests to the backend server, and updated port mappings to expose only HTTPS (443) and HTTP (80) externally. The backend server is now only accessible internally. (`demo/docker-compose.yml`, `demo/Caddyfile`) [[1]](diffhunk://#diff-e6a7f0e1cacaddea62af1fac78333e5e772e50992fb1fa6b3e3143412d5c95d6R12-R31) [[2]](diffhunk://#diff-b616949deb04c58fab7964ee4f3e91316e2da6f966636d4058b946ce4c8ec3d4R1-R4)
* Updated agent services in Docker Compose to depend on Caddy instead of the backend server directly, ensuring agents connect via the proxy. (`demo/docker-compose.yml`) [[1]](diffhunk://#diff-e6a7f0e1cacaddea62af1fac78333e5e772e50992fb1fa6b3e3143412d5c95d6R12-R31) [[2]](diffhunk://#diff-e6a7f0e1cacaddea62af1fac78333e5e772e50992fb1fa6b3e3143412d5c95d6L31-R58)

**Configuration and TLS verification:**

* Introduced a new `insecure_skip_verify` configuration option in both the config struct and YAML files, allowing agents to skip TLS certificate verification (useful for self-signed/internal CAs). (`internal/config/config.go`, `gofim.yml`, `demo/alpha.gofim.yml`, `demo/bravo.gofim.yml`, `demo/charlie.gofim.yml`) [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR22) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR36) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR91) [[4]](diffhunk://#diff-89b676868ed801ad8f97d582f426873dc9dac699b5afda443eaed8c90a7ddb6eR27-R30) [[5]](diffhunk://#diff-ed493c47191a99200ffc099edf264bfba72801f6bbbacf4bb0e0c9bd4d5e63d5L15-R16) [[6]](diffhunk://#diff-993dd1ab25e5ec15a1631620ee91ae9f2c937d1993fa8e8192f183571dd8c86aL15-R16) [[7]](diffhunk://#diff-3f19a2f4e5c9d07d9368746ff734ac2d03a7d77f682b1df3847524d838bbd1a3L15-R16)
* Updated the client initialization to accept and use the new `insecure_skip_verify` setting, configuring the HTTP client's TLS transport accordingly. (`internal/client/client.go`, `cmd/go-fim/main.go`) [[1]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514R9) [[2]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L42-R51) [[3]](diffhunk://#diff-2fe4347cafd7f2ee352369abc9008df58468c3c292e64a31eb91b5a081eb80dcL62-R62)

These changes make the demo environment more realistic and secure, while also providing flexibility for local development and testing with self-signed certificates.