### PR TITLE
Add automated installation scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ builds:
 archives:
   - id: default
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - README.md
       - LICENSE*

--- a/README.md
+++ b/README.md
@@ -150,33 +150,54 @@ The compose file bind-mounts paths under `$HOME/Developer/...` — edit `demo/do
 
 ## Installation
 
+### Quick Install (Recommended)
+
+**Linux / macOS:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.sh | bash
+sudo mv go-fim /usr/local/bin/
+```
+
+**Windows (PowerShell):**
+```powershell
+iwr -useb https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.ps1 | iex
+# Then move go-fim.exe to a directory in your PATH
+```
+
 ### From source
 
 ```bash
 go install github.com/Jimzical/go-fim/cmd/go-fim@latest
 ```
 
-### From GitHub Releases
+### Manual download from GitHub Releases
 
-Download a pre-built binary for your platform (replace `VERSION` with the tag, e.g. `1.0.0`):
+Download a pre-built binary for your platform from the [releases page](https://github.com/Jimzical/go-fim/releases).
 
+**Linux / macOS:**
 ```bash
 VERSION=1.0.0
 
 # Linux (amd64)
 curl -Lo go-fim.tar.gz https://github.com/Jimzical/go-fim/releases/download/v${VERSION}/go-fim_${VERSION}_linux_amd64.tar.gz
 tar -xzf go-fim.tar.gz && chmod +x go-fim
+sudo mv go-fim /usr/local/bin/
 
 # macOS (Apple Silicon)
 curl -Lo go-fim.tar.gz https://github.com/Jimzical/go-fim/releases/download/v${VERSION}/go-fim_${VERSION}_darwin_arm64.tar.gz
 tar -xzf go-fim.tar.gz && chmod +x go-fim
+sudo mv go-fim /usr/local/bin/
 
 # macOS (Intel)
 curl -Lo go-fim.tar.gz https://github.com/Jimzical/go-fim/releases/download/v${VERSION}/go-fim_${VERSION}_darwin_amd64.tar.gz
 tar -xzf go-fim.tar.gz && chmod +x go-fim
+sudo mv go-fim /usr/local/bin/
 ```
 
-For Windows, download the `.zip` from the [releases page](https://github.com/Jimzical/go-fim/releases).
+**Windows:**
+1. Download the `.zip` file for your architecture from the [releases page](https://github.com/Jimzical/go-fim/releases)
+2. Extract `go-fim.exe`
+3. Add to a directory in your PATH
 
 ## Releasing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,64 @@
+# Installation Scripts
+
+Simple scripts to download go-fim binary to your current directory.
+
+## `install.sh` (Linux / macOS)
+
+```bash
+# Latest version
+curl -sSL https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.sh | bash
+
+# Specific version
+curl -sSL https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.sh | bash -s 1.0.0
+```
+
+This downloads `go-fim` to your current directory. To install system-wide:
+```bash
+sudo mv go-fim /usr/local/bin/
+```
+
+---
+
+## `install.ps1` (Windows)
+
+```powershell
+# Latest version
+iwr -useb https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.ps1 | iex
+
+# Specific version (download script first)
+iwr -useb https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.ps1 -OutFile install.ps1
+.\install.ps1 -Version "1.0.0"
+```
+
+This downloads `go-fim.exe` to your current directory. To install system-wide:
+```powershell
+move go-fim.exe C:\Windows\System32\
+```
+
+---
+
+## Testing Locally
+
+Before pushing changes, test the scripts locally:
+
+**Linux / macOS:**
+```bash
+cd scripts
+chmod +x install.sh
+./install.sh 1.0.0
+```
+
+**Windows:**
+```powershell
+cd scripts
+.\install.ps1 -Version "1.0.0"
+```
+
+## Troubleshooting
+
+**Download fails:** Check that the version exists at https://github.com/Jimzical/go-fim/releases
+
+**Windows execution policy error:**
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -41,10 +41,11 @@ Write-Host "Downloading go-fim v$Version for windows_$arch..." -ForegroundColor 
 # Download and extract
 $url = "https://github.com/$Repo/releases/download/v$Version/go-fim_${Version}_windows_${arch}.zip"
 $zip = "$env:TEMP\go-fim-$([guid]::NewGuid()).zip"
+$extractDir = "$env:TEMP\go-fim-extract-$([guid]::NewGuid())"
 
 Invoke-WebRequest $url -OutFile $zip -UseBasicParsing
-Expand-Archive $zip -DestinationPath $env:TEMP\go-fim-extract -Force
-Move-Item "$env:TEMP\go-fim-extract\go-fim.exe" ".\go-fim.exe" -Force
-Remove-Item $zip, "$env:TEMP\go-fim-extract" -Recurse -Force -EA SilentlyContinue
+Expand-Archive $zip -DestinationPath $extractDir -Force
+Move-Item "$extractDir\go-fim.exe" ".\go-fim.exe" -Force
+Remove-Item $zip, $extractDir -Recurse -Force -EA SilentlyContinue
 
 Write-Host "Done! Downloaded: .\go-fim.exe" -ForegroundColor Green

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,39 @@
+# go-fim Windows Download Script
+# Usage: iwr -useb https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.ps1 | iex
+# Downloads go-fim.exe to the current directory
+
+param([string]$Version = "latest")
+
+$ErrorActionPreference = "Stop"
+$Repo = "Jimzical/go-fim"
+
+# Detect architecture
+$arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+try {
+    if ((Get-WmiObject Win32_Processor).Architecture -eq 12) { $arch = "arm64" }
+} catch {}
+
+# Get latest version if needed
+if ($Version -eq "latest") {
+    try {
+        Invoke-WebRequest "https://github.com/$Repo/releases/latest" -MaximumRedirection 0 -EA Stop | Out-Null
+    } catch {
+        if ($_.Exception.Response.Headers.Location) {
+            $Version = $_.Exception.Response.Headers.Location.ToString() -replace '.*/v', ''
+        }
+    }
+    if ($Version -eq "latest") { Write-Host "Failed to fetch version" -ForegroundColor Red; exit 1 }
+}
+
+Write-Host "Downloading go-fim v$Version for windows_$arch..." -ForegroundColor Cyan
+
+# Download and extract
+$url = "https://github.com/$Repo/releases/download/v$Version/go-fim_${Version}_windows_${arch}.zip"
+$zip = "$env:TEMP\go-fim-$([guid]::NewGuid()).zip"
+
+Invoke-WebRequest $url -OutFile $zip -UseBasicParsing
+Expand-Archive $zip -DestinationPath $env:TEMP\go-fim-extract -Force
+Move-Item "$env:TEMP\go-fim-extract\go-fim.exe" ".\go-fim.exe" -Force
+Remove-Item $zip, "$env:TEMP\go-fim-extract" -Recurse -Force -EA SilentlyContinue
+
+Write-Host "Done! Downloaded: .\go-fim.exe" -ForegroundColor Green

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,10 +8,21 @@ $ErrorActionPreference = "Stop"
 $Repo = "Jimzical/go-fim"
 
 # Detect architecture
-$arch = if ([Environment]::Is64BitOperatingSystem) { "amd64" } else { "386" }
+$arch = $null
 try {
-    if ((Get-WmiObject Win32_Processor).Architecture -eq 12) { $arch = "arm64" }
+    if ((Get-WmiObject Win32_Processor).Architecture -eq 12) {
+        $arch = "arm64"
+    }
 } catch {}
+
+if (-not $arch) {
+    if ([Environment]::Is64BitOperatingSystem) {
+        $arch = "amd64"
+    } else {
+        Write-Host "Unsupported Windows architecture: 32-bit Windows is not supported. Available Windows releases are amd64 and arm64." -ForegroundColor Red
+        exit 1
+    }
+}
 
 # Get latest version if needed
 if ($Version -eq "latest") {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# go-fim Download Script
+# Usage: curl -sSL https://raw.githubusercontent.com/Jimzical/go-fim/main/scripts/install.sh | bash
+# Downloads go-fim binary to the current directory
+
+set -e
+
+REPO="Jimzical/go-fim"
+VERSION="${1:-latest}"
+
+# Detect platform
+case "$(uname -s)" in
+    Linux*)  OS="linux" ;;
+    Darwin*) OS="darwin" ;;
+    *)       echo "Unsupported OS"; exit 1 ;;
+esac
+case "$(uname -m)" in
+    x86_64|amd64)  ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *)             echo "Unsupported arch"; exit 1 ;;
+esac
+
+# Get latest version if needed
+if [ "$VERSION" = "latest" ]; then
+    VERSION=$(curl -sI "https://github.com/${REPO}/releases/latest" | grep -i "location:" | sed 's/.*\/v//' | tr -d '\r\n')
+    [ -z "$VERSION" ] && echo "Failed to fetch version" && exit 1
+fi
+
+echo "Downloading go-fim v${VERSION} for ${OS}_${ARCH}..."
+
+# Download and extract
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/go-fim_${VERSION}_${OS}_${ARCH}.tar.gz"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+curl -sSL -o "$TMP/go-fim.tar.gz" "$URL" || { echo "Download failed"; exit 1; }
+tar -xzf "$TMP/go-fim.tar.gz" -C "$TMP"
+mv "$TMP/go-fim" ./go-fim
+chmod +x ./go-fim
+
+echo "Done! Downloaded: ./go-fim"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,7 @@ URL="https://github.com/${REPO}/releases/download/v${VERSION}/go-fim_${VERSION}_
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-curl -sSL -o "$TMP/go-fim.tar.gz" "$URL" || { echo "Download failed"; exit 1; }
+curl -fsSL -o "$TMP/go-fim.tar.gz" "$URL" || { echo "Download failed"; exit 1; }
 tar -xzf "$TMP/go-fim.tar.gz" -C "$TMP"
 mv "$TMP/go-fim" ./go-fim
 chmod +x ./go-fim


### PR DESCRIPTION
This PR adds first-party installation scripts for downloading released go-fim binaries and updates the release packaging/docs so users can install the tool more easily across Linux, macOS, and Windows.

Changes:

Added new Bash and PowerShell installers under scripts/ for downloading the latest or a specified release artifact.
Updated release packaging so Windows artifacts are published as .zip archives.
Expanded the main README and added script-specific documentation for quick install, manual install, and troubleshooting.